### PR TITLE
Add missing 'typing' module for django-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ django-appconf==1.0.2
 django-bootstrap3==9.1.0
 django-debug-toolbar==1.9.1
 django-jenkins==0.110.0
+typing==3.6.2  # for django-extensions
 django-extensions==1.9.8
 
 nameparser==0.5.3


### PR DESCRIPTION
I found this error when running `make`.

```
django_extensions/admin/__init__.py", line 9, in <module>
    from typing import Tuple, Dict, Callable  # NOQA
    ImportError: No module named typing
```