### PR TITLE
github actions: use ubuntu 22.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: build-and-test
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
           python-version: ["3.8", "3.11"]
@@ -20,4 +20,4 @@ jobs:
           python -m pip install "Django~=${{ matrix.django-version }}"
 
       - name: Build and Test
-        run: make
+        run: make test


### PR DESCRIPTION
Ubuntu 24.04 is not available here yet, but 22.04 will be a bit closer, and let's use that as we upgrade soon.